### PR TITLE
added missing file to install setup

### DIFF
--- a/mpc_local_planner/CMakeLists.txt
+++ b/mpc_local_planner/CMakeLists.txt
@@ -240,7 +240,7 @@ install(PROGRAMS
 )
 
 ## Mark executables and/or libraries for installation
-install(TARGETS mpc_local_planner
+install(TARGETS mpc_local_planner mpc_local_planner_utils mpc_local_planner_optimal_control
    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
 )
 install(TARGETS test_mpc_optim_node


### PR DESCRIPTION
mpc_local_planner_utils is missing from the install setup, so the planner does not run when installed from the official repo/built in an install workspace.