### PR TITLE
Remove faulty generate_messages dependency

### DIFF
--- a/mpc_local_planner/CMakeLists.txt
+++ b/mpc_local_planner/CMakeLists.txt
@@ -190,8 +190,6 @@ add_library(mpc_local_planner
 
 # Dynamic reconfigure: make sure configure headers are built before any node using them
 add_dependencies(mpc_local_planner ${PROJECT_NAME}_gencfg)
-# Generate messages before compiling the lib
-add_dependencies(mpc_local_planner ${PROJECT_NAME}_generate_messages_cpp)
 
 ## Declare a C++ executable
 ## With catkin_make all packages are built within a single CMake context


### PR DESCRIPTION
This line is unneeded since this package contains no message types and can sometimes cause this build error:
```
CMake Error at .../CMakeLists.txt:194 (add_dependencies):
  The dependency target "mpc_local_planner_generate_messages_cpp" of target
  "mpc_local_planner" does not exist.
```

Seems like bug was introduced with recent PR #18