### PR TITLE
Fix libraries of catkin_package mpc_local_planner

### DIFF
--- a/mpc_local_planner/CMakeLists.txt
+++ b/mpc_local_planner/CMakeLists.txt
@@ -149,7 +149,7 @@ generate_dynamic_reconfigure_options(
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
   INCLUDE_DIRS include ${EXTERNAL_INCLUDE_DIRS}
-  LIBRARIES mpc_local_planner_numerics mpc_local_planner_optimization
+  LIBRARIES mpc_local_planner_utils mpc_local_planner_optimal_control mpc_local_planner
   CATKIN_DEPENDS roscpp mpc_local_planner_msgs control_box_rst teb_local_planner dynamic_reconfigure
   # DEPENDS
 )


### PR DESCRIPTION
The libraries defined for the catkin package were not referenced anywhere, maybe historic names. Now providing all three libraries that are built in this package.

Before including this package in with `find_package(mpc_local_planner)` threw the following error:
```
  Project 'new_package' tried to find library
  'mpc_local_planner_numerics'.  The library is neither a target nor
  built/installed properly.  Did you compile project 'mpc_local_planner'? Did
  you find_package() it before the subdirectory containing its code is
  included?
```