### PR TITLE
Prevent reconfigure from overwriting parameters at the initialization

### DIFF
--- a/mpc_local_planner/CMakeLists.txt
+++ b/mpc_local_planner/CMakeLists.txt
@@ -135,7 +135,9 @@ set(EXTERNAL_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
 #add dynamic reconfigure api
 #find_package(catkin REQUIRED dynamic_reconfigure)
 generate_dynamic_reconfigure_options(
-  cfg/mpc_reconfigure.cfg
+  cfg/mpc_collision.cfg
+  cfg/mpc_controller.cfg
+  cfg/mpc_footprint.cfg
 )
 
 ###################################

--- a/mpc_local_planner/cfg/mpc_collision.cfg
+++ b/mpc_local_planner/cfg/mpc_collision.cfg
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+
+from dynamic_reconfigure.parameter_generator_catkin import *
+
+gen = ParameterGenerator()
+
+# This unusual line allows to reuse existing parameter definitions
+# that concern all localplanners
+#add_generic_localplanner_params(gen)
+
+# For integers and doubles:
+#       Name                    Type      Reconfiguration level
+#       Description
+#       Default  Min  Max
+
+# Collision avoidance
+
+grp_collision = gen.add_group("Collision avoidance", type="tab")
+
+grp_collision.add("include_costmap_obstacles", bool_t, 0, "Specify whether the obstacles in the costmap should be taken into account directly (this is necessary if no seperate clustering and detection is implemented)", True)
+
+grp_collision.add("costmap_obstacles_behind_robot_dist", double_t, 0, "Limit the occupied local costmap obstacles taken into account for planning behind the robot (specify distance in meters)", 1.5, 0, 10)
+
+grp_collision.add("collision_check_min_resolution_angular", double_t, 0, "", 3.1415, -3.1415, 3.1415)
+grp_collision.add("collision_check_no_poses", int_t, 0, "", -1, -1, 100)
+
+
+exit(gen.generate("mpc_local_planner", "mpc_local_planner", "CollisionReconfigure"))

--- a/mpc_local_planner/cfg/mpc_controller.cfg
+++ b/mpc_local_planner/cfg/mpc_controller.cfg
@@ -29,22 +29,5 @@ grp_controller.add("max_global_plan_lookahead_dist", double_t, 0, "Specify maxim
 
 grp_controller.add("global_plan_viapoint_sep", double_t, 0, "Min. separation between each two consecutive via-points extracted from the global plan [if negative: disabled]", -1, -1, 10)
 
-grp_footprint = gen.add_group("Footprint", type="tab")
 
-# Footprint model
-
-grp_footprint.add("is_footprint_dynamic", bool_t, 0, "If true, updated the footprint before checking trajectory feasibility", False)
-
-grp_collision = gen.add_group("Collision avoidance", type="tab")
-
-# Collision avoidance
-
-grp_collision.add("include_costmap_obstacles", bool_t, 0, "Specify whether the obstacles in the costmap should be taken into account directly (this is necessary if no seperate clustering and detection is implemented)", True)
-
-grp_collision.add("costmap_obstacles_behind_robot_dist", double_t, 0, "Limit the occupied local costmap obstacles taken into account for planning behind the robot (specify distance in meters)", 1.5, 0, 10)
-
-grp_collision.add("collision_check_min_resolution_angular", double_t, 0, "", 3.1415, -3.1415, 3.1415)
-grp_collision.add("collision_check_no_poses", int_t, 0, "", -1, -1, 100)
-
-
-exit(gen.generate("mpc_local_planner", "mpc_local_planner", "MpcLocalPlannerReconfigure"))
+exit(gen.generate("mpc_local_planner", "mpc_local_planner", "ControllerReconfigure"))

--- a/mpc_local_planner/cfg/mpc_footprint.cfg
+++ b/mpc_local_planner/cfg/mpc_footprint.cfg
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+from dynamic_reconfigure.parameter_generator_catkin import *
+
+gen = ParameterGenerator()
+
+# This unusual line allows to reuse existing parameter definitions
+# that concern all localplanners
+#add_generic_localplanner_params(gen)
+
+# For integers and doubles:
+#       Name                    Type      Reconfiguration level
+#       Description
+#       Default  Min  Max
+
+# Footprint model
+
+grp_footprint = gen.add_group("Footprint", type="tab")
+
+grp_footprint.add("is_footprint_dynamic", bool_t, 0, "If true, updated the footprint before checking trajectory feasibility", False)
+
+exit(gen.generate("mpc_local_planner", "mpc_local_planner", "FootprintReconfigure"))

--- a/mpc_local_planner/include/mpc_local_planner/mpc_local_planner_ros.h
+++ b/mpc_local_planner/include/mpc_local_planner/mpc_local_planner_ros.h
@@ -59,7 +59,9 @@
 
 // dynamic reconfigure
 #include <dynamic_reconfigure/server.h>
-#include <mpc_local_planner/MpcLocalPlannerReconfigureConfig.h>
+#include <mpc_local_planner/ControllerReconfigureConfig.h>
+#include <mpc_local_planner/CollisionReconfigureConfig.h>
+#include <mpc_local_planner/FootprintReconfigureConfig.h>
 
 #include <boost/shared_ptr.hpp>
 
@@ -263,13 +265,31 @@ class MpcLocalPlannerROS : public nav_core::BaseLocalPlanner, public mbf_costmap
     void updateViaPointsContainer(const std::vector<geometry_msgs::PoseStamped>& transformed_plan, double min_separation);
 
     /**
-     * @brief Callback for the dynamic_reconfigure node.
+     * @brief Callback for the dynamic_reconfigure controller node.
      *
      * This callback allows to modify parameters dynamically at runtime without restarting the node
      * @param config Reference to the dynamic reconfigure config
      * @param level Dynamic reconfigure level
      */
-    void reconfigureCB(MpcLocalPlannerReconfigureConfig& config, uint32_t level);
+    void reconfigureControllerCB(ControllerReconfigureConfig& config, uint32_t level);
+
+    /**
+     * @brief Callback for the dynamic_reconfigure collision node.
+     *
+     * This callback allows to modify parameters dynamically at runtime without restarting the node
+     * @param config Reference to the dynamic reconfigure config
+     * @param level Dynamic reconfigure level
+     */
+    void reconfigureCollisionCB(CollisionReconfigureConfig& config, uint32_t level);
+
+    /**
+     * @brief Callback for the dynamic_reconfigure footprint collision node.
+     *
+     * This callback allows to modify parameters dynamically at runtime without restarting the node
+     * @param config Reference to the dynamic reconfigure config
+     * @param level Dynamic reconfigure level
+     */
+    void reconfigureFootprintCB(FootprintReconfigureConfig& config, uint32_t level);
 
     /**
      * @brief Callback for custom obstacles that are not obtained from the costmap
@@ -378,8 +398,12 @@ class MpcLocalPlannerROS : public nav_core::BaseLocalPlanner, public mbf_costmap
     pluginlib::ClassLoader<costmap_converter::BaseCostmapToPolygons> _costmap_converter_loader;  //!< Load costmap converter plugins at runtime
     boost::shared_ptr<costmap_converter::BaseCostmapToPolygons> _costmap_converter;              //!< Store the current costmap_converter
 
-    boost::shared_ptr<dynamic_reconfigure::Server<MpcLocalPlannerReconfigureConfig>>
-        dynamic_recfg_;                                        //!< Dynamic reconfigure server to allow config modifications at runtime
+    boost::shared_ptr<dynamic_reconfigure::Server<ControllerReconfigureConfig>>
+        dynamic_controller_recfg_;                             //!< Dynamic reconfigure server to allow config modifications at runtime
+    boost::shared_ptr<dynamic_reconfigure::Server<CollisionReconfigureConfig>>
+        dynamic_collision_recfg_;                              //!< Dynamic reconfigure server to allow config modifications at runtime
+    boost::shared_ptr<dynamic_reconfigure::Server<FootprintReconfigureConfig>>
+        dynamic_footprint_recfg_;                              //!< Dynamic reconfigure server to allow config modifications at runtime
     ros::Subscriber _custom_obst_sub;                          //!< Subscriber for custom obstacles received via a ObstacleMsg.
     std::mutex _custom_obst_mutex;                             //!< Mutex that locks the obstacle array (multi-threaded)
     costmap_converter::ObstacleArrayMsg _custom_obstacle_msg;  //!< Copy of the most recent obstacle message


### PR DESCRIPTION
During my testing, I run into one bug regarding reconfigure parameters loading. During initialization parameters from launch files and .yamls will be overwritten with the default ones from the .cfg file. To prevent this to be happening, params from .yamls and ones from .cfg files should have the same names. Now, they don't have the same names due to missing prefixes - `controller`, `footprint_model` and 'collision' inside .cfg files, so parameters from .yaml files are overwritten inside reconfigure callback.

Config file cheks is there parameter with the same name, if there is, the default value from params server will be used, and not the one specified from the user inside cfg file. 
See: https://answers.ros.org/question/28327/dynamic-reconfigure-default-parameters/?answer=28332#post-id-28332